### PR TITLE
Update CAMARA-API-access-and-user-consent.md login_hint example

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -281,7 +281,7 @@ The API invoker has to provide in the authorization request (/bc_authorize) a lo
 
     ```
     POST /bc-authorize HTTP/1.1
-    Authorization: Basic {Credentials}
+    Authorization: ...
     Content-Type: application/x-www-form-urlencoded
 
     login_hint=tel%3A%2B346xxyyyzzz&


### PR DESCRIPTION
CIBA does require the authorization request to be authenticated but allows a wide range of methods.

Removing "Basic" from the example

#### What type of PR is this?
* cleanup

#### What this PR does / why we need it:

Clarification that Basic authentication is not important for the example. The login_hint part is.


#### Which issue(s) this PR fixes:

Fixes #104 

