### PR TITLE
Fix broken link - Issue #97

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -213,7 +213,7 @@ The technical ruleset is applicable only after a subproject has agreed to use a 
 
 If all API usecases point to the need of On-net scenario and where the consumption device and authentication device are the same, the Frontend flow should be used. eg. NumberVerification
 
-This flow is then applicable to On-net scenarios where the mobile connection of the device needs to be authenticated e.g. This flow is for example the one specified for the [CAMARA Number Verification API](https://github.com/camaraproject/NumberVerification/blob/main/documentation/API_documentation/CAMARA/uml_v0.3.jpg) due to the nature of its functionality where a given MSISDN needs to be compared to the MSISDN associated with the mobile connection of the user device. 
+This flow is then applicable to On-net scenarios where the mobile connection of the device needs to be authenticated e.g. This flow is for example the one specified for the [CAMARA Number Verification API](https://github.com/camaraproject/NumberVerification/blob/main/documentation/API_documentation/assets/uml_v0.3.jpg) due to the nature of its functionality where a given MSISDN needs to be compared to the MSISDN associated with the mobile connection of the user device. 
 
 
 The device application (front-end) must be able to handle browser redirects.


### PR DESCRIPTION
#### What type of PR is this?

* correction
* documentation

#### What this PR does / why we need it:

Link to referense [CAMARA Number Verification API](https://github.com/camaraproject/NumberVerification/blob/main/documentation/API_documentation/CAMARA/uml_v0.3.jpg) is broken (404 page not found). It updates reference URL.

#### Which issue(s) this PR fixes:

Fixes #97

#### Special notes for reviewers:

@bhjelm Please review it as issue #97 owner.

#### Changelog input

N/A

#### Additional documentation 

N/A