### PR TITLE
Add rule for requesting scopes for client credentials

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -80,7 +80,7 @@ A purpose must be declared within the requested scope for the following grant ty
 - authorization_code
 - urn:openid:params:grant-type:ciba
 
-For the client_credentials grant type, the requested scope must be set directly to the value defined for the relevant endpoint within the OAS ("YAML") specification. "Wild card" scopes (i.e. specifying only the API name) are not valid for this grant types.
+No purpose is required for the client_credentials grant type, as this grant type can only be used when no personal user data is processed. The requested scope must be set directly to the value defined for the relevant endpoint within the OAS ("YAML") specification. "Wild card" scopes (i.e. specifying only the API name) are not valid for this grant type.
 
 In order to declare a purpose when accessing the CAMARA APIs, it is strongly recommended that the `scope' parameter is set to:
 

--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -76,6 +76,12 @@ A purpose declares what the application intends to do with a set of personal inf
 
 ### Applying purpose concept in the authorization request
 
+A purpose must be declared within the requested scope for the following grant types:
+- authorization_code
+- urn:openid:params:grant-type:ciba
+
+For the client_credentials grant type, the requested scope must be set directly to the value defined for the relevant endpoint within the OAS ("YAML") specification. "Wild card" scopes (i.e. specifying only the API name) are not valid for this grant types.
+
 In order to declare a purpose when accessing the CAMARA APIs, it is strongly recommended that the `scope' parameter is set to:
 
 `dpv:<dpvValue>#<technicalParameter>`


### PR DESCRIPTION
#### What type of PR is this?
* documentation

#### What this PR does / why we need it:
Defines how scope requests are constructed when using the client_credentials grant type

#### Which issue(s) this PR fixes:
Fixes #92 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Add rule for requesting scopes for client credentials
```

#### Additional documentation 
None