### PR TITLE
Adapt info.description to Security and Interoperablity Profile

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -425,7 +425,9 @@ The documentation template below must be used as part of the API documentation i
 ```
 ### Authorization and authentication
 
-CAMARA guidelines defines a set of authorization flows which can grant API clients access to the API functionality, as outlined in the document [CAMARA-API-access-and-user-consent.md](https://github.com/camaraproject/IdentityAndConsentManagement/blob/main/documentation/CAMARA-API-access-and-user-consent.md). Which specific authorization flows are to be used will be determined during onboarding process, happening between the API Client and the Telco Operator exposing the API, taking into account the declared purpose for accessing the API, while also being subject to the prevailing legal framework dictated by local legislation.
+[Camara Security and Interoperability Profile](https://github.com/camaraproject/IdentityAndConsentManagement/blob/main/documentation/CAMARA-Security-Interoperability.md) provides details on how a client requests an access token.
+
+Which specific authorization flows are to be used will be determined during onboarding process, happening between the API Client and the Telco Operator exposing the API, taking into account the declared purpose for accessing the API, while also being subject to the prevailing legal framework dictated by local legislation.
 
 It is important to remark that in cases where personal user data is processed by the API, and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of 3-legged access tokens becomes mandatory. This measure ensures that the API remains in strict compliance with user privacy preferences and regulatory obligations, upholding the principles of transparency and user-centric data control.
 ```


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

The issue https://github.com/camaraproject/IdentityAndConsentManagement/issues/154 requests: 
> Clean up and update the CAMARA-API-access-and-user-consent.md document to reflect the latest profile decisions and/or to include references(*) to the new profile document where appropriate.

This PR updates the info.description section of CAMARA-API-access-and-user-consent.md that the information that API subgroups are requested to put into their OpenAPI yaml file points to the [Camara Security and Interoperability Profile](https://github.com/camaraproject/IdentityAndConsentManagement/blob/main/documentation/CAMARA-Security-Interoperability.md).



#### Which issue(s) this PR fixes:

Related issue: https://github.com/camaraproject/IdentityAndConsentManagement/issues/154

