### PR TITLE
Proposed text on network-based authentication

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -140,7 +140,7 @@ As per the standard authorization code flow, the device application is redirecte
 
 The API exposure platform receives the request from the device application (Step 3) and does the following:
 
-- Use network based authentication mechanism to obtain the subscription identifier, i.e.: MSISDN or IMSI. Set the id_token sub to some unique user ID and associate the sub with the access token. The id_token sub SHOULD not reveal information to the API consumer that they not already know, e.g. using the MSISDN as a sub might violate privacy. (Step 4).
+- Use network based authentication mechanism to obtain the subscription identifier,e.g.: phone number or IMSI. Set the id_token sub to some unique user ID and associate the sub with the access token. The id_token sub SHOULD NOT reveal information to the API consumer that they not already know, e.g. using the MSISDN as a sub might violate privacy. (Step 4).
 
 - Check if user consent is required, which depends on the legal basis associated with the purpose ("legitimate interest", "contract", "consent", etc). If necessary, it will check in the operator's consent master whether user consent has already been given for this identifier, the application client_id and the requested purpose (Steps 5-6).
 

--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -140,7 +140,7 @@ As per the standard authorization code flow, the device application is redirecte
 
 The API exposure platform receives the request from the device application (Step 3) and does the following:
 
-- Use network based authentication mechanism to obtain the user identifier, i.e.: MSISDN. Set the OAuth sub to the unique user ID in the operator (Step 4).
+- Use network based authentication mechanism to obtain the subscription identifier, i.e.: MSISDN or IMSI. Set the id_token sub to some unique user ID and associate the sub with the access token. The id_token sub SHOULD not reveal information to the API consumer that they not already know, e.g. using the MSISDN as a sub might violate privacy. (Step 4).
 
 - Check if user consent is required, which depends on the legal basis associated with the purpose ("legitimate interest", "contract", "consent", etc). If necessary, it will check in the operator's consent master whether user consent has already been given for this identifier, the application client_id and the requested purpose (Steps 5-6).
 


### PR DESCRIPTION
There is no OAuth sub in [OAuth2](https://datatracker.ietf.org/doc/html/rfc6749).
There is an id_token.sub in OIDC.

Network authentication identifies the subscription which is primarily defined by the IMSI.
If there is a one-to-one relationship between between IMSI and MSISDN then network authentication also identifies the MSISDN. If one subscriber has multiple SIMs with the same MSISDN then things might go wrong for the Camara API, because the user might want some QoD for the device they are currently using but not for the other with the same.


#### What type of PR is this?

* correction

#### What this PR does / why we need it:

- replace OAuth sub
- Describe what network authentication does 
- Clarify that globally unique and long-term identifiers like MSISDN must not be handed to the API consumer in id_token.sub. Also associate `sub` with the access token.
