### PR TITLE
Fix returned error in authentication code flow

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -114,7 +114,7 @@ alt Standard OIDC Auth Code Flow between Invoker and API Exposure Platform
   else If Consent is NOT granted - Consent Capture within AuthCode Flow  
     Note over FE,ExpO: Start user consent capture process<br>following Section 3.1.2.4 of the OIDC Core 1.0 spec.    
     alt If the user refuses consent
-      ExpO-->>FE: 400 Bad Request <br> {error: access_denied}
+      ExpO-->>FE: 302<br>Location: invoker_callback?error=access_denied
     else If the user grants consent
       ExpO-->>FE: 302<br>Location: invoker_callback?code=Operatorcode
     end


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

According to OAuth 2.0 ([RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1)), if the resource owner denies the request, the response should redirect the user-agent to the client redirection URI by adding the `error` parameter with `access_denied` value.

> If the resource owner denies the access request or if the request fails for reasons other than a missing or invalid redirection URI, the authorization server informs the client by adding the following parameters to the query component of the redirection URI using the"application/x-www-form-urlencoded" format [...]


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

#### Special notes for reviewers:

#### Changelog input

#### Additional documentation 
