### PR TITLE
Fix W3C DPV broken links in ICM doc

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -65,7 +65,7 @@ A purpose declares what the application intends to do with a set of personal inf
 
 ### Purpose definition
 
-The purpose definition (naming + description) and format for CAMARA follows the W3C [Data Privacy Vocabulary](https://www.w3.org/community/dpvcg/)​ (DPV). The way in which purposes are organised within the DPV is specified in [Purpose taxonomy in DPV](https://w3c.github.io/dpv/dpv/#vocab-purposes).
+The purpose definition (naming + description) and format for CAMARA follows the W3C [Data Privacy Vocabulary](https://w3c.github.io/dpv/)​ (DPV). The way in which purposes are organised within the DPV is specified in [Purpose taxonomy in DPV](https://w3c.github.io/dpv/2.0/dpv/#vocab-purposes).
 
 ### Applying purpose concept in the authorization request
 

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -222,7 +222,7 @@ Purpose is one of the scope parameter's values. There MUST be exactly one purpos
 
 The Authorization Server identifies the purpose using the prefix `dpv:`.
 
-This scope MUST have the following format: `dpv:<dpvValue>` where `<dpvValue>` is coming from [W3C DPV purpose definition](https://w3c.github.io/dpv/dpv/#vocab-purpose)
+This scope MUST have the following format: `dpv:<dpvValue>` where `<dpvValue>` is coming from [W3C DPV purpose definition](https://w3c.github.io/dpv/2.0/dpv/#vocab-purposes)
 
 
 
@@ -267,7 +267,7 @@ Camara recommends that implementations run the OIDF interoperability suite and a
 
 ## References
 
-* [Data Privacy Vocabulary (DPV)](https://w3c.github.io/dpv/dpv/)
+* [Data Privacy Vocabulary (DPV)](https://w3c.github.io/dpv/2.0/dpv/)
 * [E.164 - The international public telecommunication numbering plan](https://www.itu.int/rec/T-REC-E.164-201011-I/en)
 * [OpenID Connect Core 1.0 specification](https://openid.net/specs/openid-connect-core-1_0.html)
 * [OpenID Connect Client-Initiated Backchannel Authentication Flow - Core 1.0](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html)


### PR DESCRIPTION
#### What type of PR is this?

* correction
* documentation

#### What this PR does / why we need it:

W3C Data Privacy Vocabulary (DPV) reference links in ICM documentation are broken. This PR fixes the broken links in the required documents.

#### Which issue(s) this PR fixes:

Fixes #195

#### Special notes for reviewers:

N/A

#### Changelog input

```
Fix W3C Data Privacy Vocabulary (DPV) broken reference links

```

#### Additional documentation 

N/A
