### PR TITLE
ICM patch release r0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,24 @@
 
 ## Table of Contents
 
+- [r0.2.1](#r021)
 - [r0.2.0](#r020)
 - [r0.2.0-rc.2](#r020-rc2)
 - [v0.2.0-rc.1](#v020-rc1)
 - [v0.1.0 - Initial version](#v010---initial-version)
+
+# r0.2.1
+
+**This is the public release of "Identity And Consent Management" version 0.2.1, a patch release from r0.2.0**
+
+## Please note:
+
+* The r0.2.1 release is a patch release of r0.2.0. **Please read also the release notes and changes of [r0.2.0](#r020)**.
+
+### Fixed
+* Fixed broken W3C Data Privacy Vocabulary (DPV) reference links in ICM documentation by @jpengar in https://github.com/camaraproject/IdentityAndConsentManagement/pull/196
+
+**Full Changelog**: https://github.com/camaraproject/IdentityAndConsentManagement/compare/r0.2.0...r0.2.1
 
 # r0.2.0
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Repository to describe, develop, document and test the Identity And Consent Mana
 
 ## Release Information
 
-* `NEW`: Release 0.2.0 of the "Identity and Consent Management" guidelines and documentation for the CAMARA APIs is available under the tag [r0.2.0](https://github.com/camaraproject/IdentityAndConsentManagement/tree/r0.2.0). It contains the current version of the documents which are relevant for [Fall24 meta-release](https://wiki.camaraproject.org/display/CAM/Meta-release+Fall24), including:
-  * [CAMARA APIs access and user consent management](https://github.com/camaraproject/IdentityAndConsentManagement/blob/r0.2.0/documentation/CAMARA-API-access-and-user-consent.md)
-  * [Camara Security and Interoperability Profile](https://github.com/camaraproject/IdentityAndConsentManagement/blob/r0.2.0/documentation/CAMARA-Security-Interoperability.md)
+* `NEW`: Release 0.2.0 of the "Identity and Consent Management" guidelines and documentation for the CAMARA APIs is available under the tag [r0.2.1](https://github.com/camaraproject/IdentityAndConsentManagement/tree/r0.2.1). It contains the current version of the documents which are relevant for [Fall24 meta-release](https://wiki.camaraproject.org/display/CAM/Meta-release+Fall24), including:
+  * [CAMARA APIs access and user consent management](https://github.com/camaraproject/IdentityAndConsentManagement/blob/r0.2.1/documentation/CAMARA-API-access-and-user-consent.md)
+  * [Camara Security and Interoperability Profile](https://github.com/camaraproject/IdentityAndConsentManagement/blob/r0.2.1/documentation/CAMARA-Security-Interoperability.md)
 * The latest **public release** of guidelines and documentation for CAMARA APIs is available [here](https://github.com/camaraproject/IdentityAndConsentManagement/releases/latest).
 * For previous releases and changes see [CHANGELOG.md](https://github.com/camaraproject/IdentityAndConsentManagement/blob/main/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@
 Repository to describe, develop, document and test the Identity And Consent Management for CAMARA APIs
 
 ## Scope
-* Telco operator exposure platforms implementing CAMARA APIs should be built with a privacy-by-default approach to fully comply with data protection regulations, such as the GDPR regulation in Europe, which emphasises on user privacy. These regulations note that some CAMARA APIs may require user consent to be accessed. This forces the operators to provide means and appropriate solutions to capture, store and manage this consent through its lifecycle. Otherwise, the scoped CAMARA APIs cannot be rolled out in production networks. Building such a solution also means bringing in scope the identity of the end user and/or the subscriber (as both could be different) and making sure that end user experience of using the API is not compromised while doing so.
+* API providers implementing CAMARA APIs should be built with a privacy-by-default approach to fully comply with data protection regulations, such as the GDPR regulation in Europe, which emphasizes on user privacy. These regulations note that some CAMARA APIs may require user consent to be accessed. This forces the API provider to provide means and appropriate solutions to capture, store and manage this consent throughout its lifecycle. Otherwise, the scoped CAMARA APIs cannot be rolled out in production networks. Building such a solution also means bringing the identity of the user into scope and ensuring that the user experience when using the API is not compromised.
 * Started: March 2023
 
 ## Release Information
 
-* `NEW`: Release 0.2.0 of the "Identity and Consent Management" guidelines and documentation for the CAMARA APIs is available under the tag [r0.2.1](https://github.com/camaraproject/IdentityAndConsentManagement/tree/r0.2.1). It contains the current version of the documents which are relevant for [Fall24 meta-release](https://wiki.camaraproject.org/display/CAM/Meta-release+Fall24), including:
+* `NEW`: Release 0.2.1 of the "Identity and Consent Management" guidelines and documentation for the CAMARA APIs is available under the tag [r0.2.1](https://github.com/camaraproject/IdentityAndConsentManagement/tree/r0.2.1). It contains the current version of the documents which are relevant for [Fall24 meta-release](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14549015/Meta-release+Fall24), including:
   * [CAMARA APIs access and user consent management](https://github.com/camaraproject/IdentityAndConsentManagement/blob/r0.2.1/documentation/CAMARA-API-access-and-user-consent.md)
   * [Camara Security and Interoperability Profile](https://github.com/camaraproject/IdentityAndConsentManagement/blob/r0.2.1/documentation/CAMARA-Security-Interoperability.md)
 * The latest **public release** of guidelines and documentation for CAMARA APIs is available [here](https://github.com/camaraproject/IdentityAndConsentManagement/releases/latest).
@@ -26,7 +26,7 @@ Repository to describe, develop, document and test the Identity And Consent Mana
 * Meetings
   * [Registration / Join](https://zoom-lfx.platform.linuxfoundation.org/meeting/94629188836?password=278b4c8a-f370-43bf-bac1-b30a39f169f3)
    * Schedule: Bi-weekly Wednesday, 16:00 CEST (14:00 UTC during European daylight saving time)
-  * Minutes: Access [meeting minutes](https://wiki.camaraproject.org/x/2QBFAQ).
+  * Minutes: Access [meeting minutes](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14569108/ICM+Meeting+Minutes).
 * Maling List
   * Subscribe / Unsubscribe to the mailing list of this Sub Project <https://lists.camaraproject.org/g/wg-icm>.
   * A message to the community of this Sub Project can be sent using <wg-icm@lists.camaraproject.org>.


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

This PR is to update the README and CHANGELOG files for the r0.2.1 patch release. This patch release fixes broken W3C Data Privacy Vocabulary (DPV) reference links in the ICM documentation.
The original idea was to create a maintenance release (and maintenance branch) where this needed fix would be applied. However, there are still some pending discussions about maintenance releases in the Release Management Working Group, and as a short-term solution it was suggested by @hdamker (https://github.com/camaraproject/IdentityAndConsentManagement/pull/196#issuecomment-2343801035) to create a patch release in the `main` branch.

#### Which issue(s) this PR fixes:

N/A (It is related to Issue #195 and the fix applied in PR #196)

#### Special notes for reviewers:

See #196 for further context.

#### Changelog input

```
 ICM patch release r0.2.1
```

#### Additional documentation 

https://github.com/camaraproject/ReleaseManagement/issues/93