### PR TITLE
PR #182 split - info.description template review (part 3 of 3)

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -356,7 +356,7 @@ The documentation template below must be used as part of the API documentation i
 
 The "Camara Security and Interoperability Profile" provides details on how a client requests an access token.
 
-The specific authorization flows to be used will be determined during onboarding process, happening between the API client and the telco operator exposing the API, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
+The specific authorization flows to be used will be determined during the onboarding process, happening between the API client and the operator exposing the API, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
 In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
 ```

--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -354,9 +354,9 @@ The documentation template below must be used as part of the API documentation i
 ```
 ### Authorization and authentication
 
-The "Camara Security and Interoperability Profile" provides details on how a client requests an access token.
+The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
 
-The specific authorization flows to be used will be determined during the onboarding process, happening between the API client and the operator exposing the API, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
+The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the provider of the application consumig the API and the operator's API exposure platfom, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
 In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
 ```

--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -349,17 +349,16 @@ The {scope} is the specific scope defined to protect this operation.
 
 ### Mandatory template for `info.description` in CAMARA API specs
 
-The documentation template below must be used as part of the API documentation in  `info.description` property in the CAMARA API specs:
-
+The documentation template below must be used as part of the API documentation in `info.description` property in the CAMARA API specs:
 
 ```
 ### Authorization and authentication
 
-The "Camara Security and Interoperability Profile" provides details on how a client requests an access token. Please refer to Identify and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the Profile.
+The "Camara Security and Interoperability Profile" provides details on how a client requests an access token.
 
-Which specific authorization flows are to be used will be determined during onboarding process, happening between the API Client and the Telco Operator exposing the API, taking into account the declared purpose for accessing the API, while also being subject to the prevailing legal framework dictated by local legislation.
+The specific authorization flows to be used will be determined during onboarding process, happening between the API client and the telco operator exposing the API, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
-It is important to remark that in cases where personal user data is processed by the API, and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of 3-legged access tokens becomes mandatory. This measure ensures that the API remains in strict compliance with user privacy preferences and regulatory obligations, upholding the principles of transparency and user-centric data control.
+In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
 ```
 
-It tells potential API customers why the API specification does not list specific grant types, and how to find out what authorization flows they can use.
+This statement informs potential API customers why the API specification does not list specific grant types and how to find out which authorization flows they can use.

--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -342,7 +342,7 @@ The documentation template below must be used as part of the API documentation i
 
 The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
 
-The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the provider of the application consumig the API and the operator's API exposure platfom, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
+The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the provider of the application consuming the API and the operator's API exposure platform, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
 
 In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
 ```


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

As discussed by the team in [11/09 WG call](https://lf-camaraproject.atlassian.net/l/cp/xHd81isJ), in order to move things forward, we are going to split the content of PR #182 into three different PRs:

* One focused on just updating the terms and definitions. So that the WG can agree on the terms to be used in the rest of the documentation. Initially it keeps original changes proposed in #182.
  * https://github.com/camaraproject/IdentityAndConsentManagement/pull/212
* Another editorial one, simply including the same "better English" changes proposed in #182. It assumes for the moment that the terms and definitions are the ones initially proposed. Then the document may need some adjustments later if something is changed in the previous PR and this one is already merged. This "better English" one will probably be the easiest to approve.
  * https://github.com/camaraproject/IdentityAndConsentManagement/pull/213
* ❗**THIS PR**❗And finally, another independent PR just for changes in the `info.description` template, which could also fix other issues like https://github.com/camaraproject/IdentityAndConsentManagement/issues/178.
  * https://github.com/camaraproject/IdentityAndConsentManagement/pull/214

The WG concluded that it would be much easier to deal with if we separated the proposed changes in #182 into different PRs.

#### Which issue(s) this PR fixes:

Fixes #178
Fixes #190 
Fixes #200  

#### Special notes for reviewers:

Further context in https://github.com/camaraproject/IdentityAndConsentManagement/pull/182

CC @chrishowell 

#### Changelog input

```
Improved document writing

```

#### Additional documentation 

N/A
