### PR TITLE
operator token login_hint format

### DIFF
--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -108,12 +108,12 @@ This CAMARA document clarifies the values used in login_hint in the following wa
 
     For IPv4 and IPv6 addresses, that can optionally include a port. For example, `ipport:80.90.34.2:16790`, `ipport:80.90.34.2`, `ipport:[2001:db8::1]:8080` or `ipport:[2001:db8::1]`.
 
-  * **_ot_**
+  * **_operatortoken_**
 
     For operator tokens as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/).
     TS.43 does not specify the format of the operator token and it therefore might contain characters that are not url-safe.
     This document specifies that the API consumer must encode the operator token using [base64url](https://www.rfc-editor.org/rfc/rfc7515.html#appendix-C) encoding to make it urlsafe.
-    For example, `ot:ZXhhbXBsZQ`
+    For example, `operatortoken:ZXhhbXBsZQ`
     
    This document does not specifiy how the API consumer got the operatorToken. 
 

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -100,14 +100,34 @@ The client MUST authenticate with the authorization server as described in [Clie
 
 This CAMARA document clarifies the values used in login_hint in the following way:
 
-    * **_tel_**
+  * **_tel_**
 
-      For phone numbers. The `login_hint` must be a tel URI as defined in [RFC 3966](https://www.rfc-editor.org/info/rfc3966) for global phone numbers without visual separators in [E.164](https://www.itu.int/rec/T-REC-E.164-201011-I/en) format. For example, `tel:+34666666666`.
+    For phone numbers. The `login_hint` must be a tel URI as defined in [RFC 3966](https://www.rfc-editor.org/info/rfc3966) for global phone numbers without visual separators in [E.164](https://www.itu.int/rec/T-REC-E.164-201011-I/en) format. For example, `tel:+34666666666`.
 
-    * **_ipport_**
+  * **_ipport_**
 
-      For IPv4 and IPv6 addresses, that can optionally include a port. For example, `ipport:80.90.34.2:16790`, `ipport:80.90.34.2`, `ipport:[2001:db8::1]:8080` or `ipport:[2001:db8::1]`.
+    For IPv4 and IPv6 addresses, that can optionally include a port. For example, `ipport:80.90.34.2:16790`, `ipport:80.90.34.2`, `ipport:[2001:db8::1]:8080` or `ipport:[2001:db8::1]`.
 
+  * **_ot_**
+
+    For operator tokens as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/).
+    TS.43 does not specify the format of the operator token and it therefore might contain characters that are not url-safe.
+    This document specifies that the API consumer must encode the operator token using [base64url](https://www.rfc-editor.org/rfc/rfc7515.html#appendix-C) encoding to make it urlsafe.
+
+    The following is a non-normative example of an OIDC authorization POST request with an ot-login_hint:
+
+```text
+    POST /authorize HTTP/1.1
+    Host: server.example.com
+    Content-Type: application/x-www-form-urlencoded
+
+    response_type=code
+      &scope=openid%20dpv:FraudPreventionAndDetection%20sim-swap:check%20sim-swap:retrieve-date
+      &client_id=s6BhdRkqt3
+      &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+      &login_hint="ot:ZXhhbXBsZQ"
+```
+   This document does not specifiy how the API consumer got the operatorToken. 
 
 ## Offline Access
 
@@ -281,4 +301,6 @@ Camara recommends that implementations run the OIDF interoperability suite and a
 * [RFC 7523 - JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants](https://www.rfc-editor.org/info/rfc7523)
 * [RFC 8259 - The JavaScript Object Notation (JSON) Data Interchange Format](https://www.rfc-editor.org/info/rfc8259)
 * [RFC 8414 - OAuth 2.0 Authorization Server Metadata](https://www.rfc-editor.org/info/rfc8414)
+* [GSMA GSMA Authorization Server – Authenticator capabilities](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/)
+* [GSMA TS.43 Service Entitlement Configuration](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/)
 

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -112,7 +112,7 @@ This CAMARA document clarifies the values used in login_hint in the following wa
 
     For operator tokens as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/).
     TS.43 does not specify the format of the operator token and it therefore might contain characters that are not url-safe.
-    This document specifies that the API consumer must encode the operator token using [base64url](https://www.rfc-editor.org/rfc/rfc7515.html#appendix-C) encoding to make it urlsafe.
+    The API consumer MUST encode the operator token using [base64url](https://www.rfc-editor.org/rfc/rfc7515.html#appendix-C) encoding to make it URL safe.
     For example, `operatortoken:ZXhhbXBsZQ`
     
    This document does not specifiy how the API consumer got the operatorToken. 

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -113,20 +113,8 @@ This CAMARA document clarifies the values used in login_hint in the following wa
     For operator tokens as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/).
     TS.43 does not specify the format of the operator token and it therefore might contain characters that are not url-safe.
     This document specifies that the API consumer must encode the operator token using [base64url](https://www.rfc-editor.org/rfc/rfc7515.html#appendix-C) encoding to make it urlsafe.
-
-    The following is a non-normative example of an OIDC authorization POST request with an ot-login_hint:
-
-```text
-    POST /authorize HTTP/1.1
-    Host: server.example.com
-    Content-Type: application/x-www-form-urlencoded
-
-    response_type=code
-      &scope=openid%20dpv:FraudPreventionAndDetection%20sim-swap:check%20sim-swap:retrieve-date
-      &client_id=s6BhdRkqt3
-      &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
-      &login_hint="ot:ZXhhbXBsZQ"
-```
+    For example, `ot:ZXhhbXBsZQ`
+    
    This document does not specifiy how the API consumer got the operatorToken. 
 
 ## Offline Access


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature


#### What this PR does / why we need it:

It was proposed to `login_hint` to convey operator token to the Camara Authorization Server.
This way OIDF and IETF standards don't need to be extended.


#### Which issue(s) this PR fixes:

Fixes #145 





