### PR TITLE
Clarify case sensitivity of parameter names and values

### DIFF
--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -51,10 +51,11 @@ By encapsulating these elements within this document, it aims to provide a compr
 
 The target audience for this document is the service/technical departments of operators exposing network functions via standard CAMARA APIs and the applications or client systems that consume CAMARA standard APIs to make use of the operator's network capabilities.
 
-
 ## Conventions
 
 The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+Unless otherwise noted, all the protocol parameter names and values are case sensitive.
 
 ## General Considerations
 


### PR DESCRIPTION
#### What type of PR is this?
* documentation

#### What this PR does / why we need it:
The CAMARA Security and Interoperability profile does not clarify whether parameter names and values are case sensitive.

It is proposed to adopt the [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-1.9) convention that parameter names and values are case sensitive unless otherwise stated.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Add document convention that parameter names and values are case-sensitive unless otherwise stated
```

#### Additional documentation 
None