### PR TITLE
Update Pull Request template with breaking change indication

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 #### What type of PR is this?
 
 <!-- Add one of the following kinds: -->
+
 * bug
 * correction
 * enhancement/feature
@@ -36,7 +37,6 @@ Fixes #
 
 ```
  release-note
-
 ```
 
 #### Additional documentation 
@@ -45,5 +45,4 @@ This section can be blank.
 
 ```
 docs
-
 ```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,8 @@
 
 #### What type of PR is this?
 
-Add one of the following kinds:
+<!-- Add one of the following kinds: -->
+* bug
 * correction
 * enhancement/feature
 * cleanup
@@ -9,9 +10,7 @@ Add one of the following kinds:
 * subproject management
 * tests
 
-
 #### What this PR does / why we need it:
-
 
 
 
@@ -21,6 +20,13 @@ Add one of the following kinds:
 Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->
 
 Fixes #
+
+#### Does this PR introduce a breaking change?
+
+- [ ] Yes
+- [ ] No
+
+<!-- If indicated yes above, please describe the breaking change(s). -->
 
 #### Special notes for reviewers:
 
@@ -36,8 +42,6 @@ Fixes #
 #### Additional documentation 
 
 This section can be blank.
-
-
 
 ```
 docs


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

This PR updates the PR template as done for Commonalities in https://github.com/camaraproject/Commonalities/pull/314

> Since some of CAMARA APIs are published as stable implementation of braking changes would require bumping up the main API version.
This should be indicated in the PR. And analyzed in its review.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:

N/A

#### Changelog input

```
 Pull Request template with breaking change indication
```

#### Additional documentation 

N/A
