### PR TITLE
Alpha release r2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ NOTE: The Working Group release numbering has been updated to adopt the same rel
 ### Changed
 
 * Updated the `CAMARA-Security-Interoperability.md` document to replace Telco and Operator terms with API Provider by @AxelNennker in https://github.com/camaraproject/IdentityAndConsentManagement/pull/201
-* Updated terms and definitions in the `CAMARA-API-access-and-user-consent.md` for better writing and understanding by @jpengar in https://github.com/camaraproject/IdentityAndConsentManagement/pull/212
+* Updated terms and definitions in the `CAMARA-API-access-and-user-consent.md` for better writing and understanding by @jpengar and @chrishowell in https://github.com/camaraproject/IdentityAndConsentManagement/pull/212
 * Updated the `CAMARA-API-access-and-user-consent.md` document with editorial and general writing improvements by @jpengar in https://github.com/camaraproject/IdentityAndConsentManagement/pull/213
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ NOTE: The Working Group release numbering has been updated to adopt the same rel
 
 * Updated the `CAMARA-Security-Interoperability.md` document to replace Telco and Operator terms with API Provider by @AxelNennker in https://github.com/camaraproject/IdentityAndConsentManagement/pull/201
 * Updated terms and definitions in the `CAMARA-API-access-and-user-consent.md` for better writing and understanding by @jpengar and @chrishowell in https://github.com/camaraproject/IdentityAndConsentManagement/pull/212
-* Updated the `CAMARA-API-access-and-user-consent.md` document with editorial and general writing improvements by @jpengar in https://github.com/camaraproject/IdentityAndConsentManagement/pull/213
+* Updated the `CAMARA-API-access-and-user-consent.md` document with editorial and general writing improvements by @jpengar and @chrishowell in https://github.com/camaraproject/IdentityAndConsentManagement/pull/213
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,53 @@
 
 ## Table of Contents
 
-- [r0.2.1](#r021)
-- [r0.2.0](#r020)
-- [r0.2.0-rc.2](#r020-rc2)
-- [v0.2.0-rc.1](#v020-rc1)
-- [v0.1.0 - Initial version](#v010---initial-version)
+- **[r2.1](#r21)**
+- **[r0.2.1](#r021)**
+- **[r0.2.0](#r020)**
+- **[r0.2.0-rc.2](#r020-rc2)**
+- **[v0.2.0-rc.1](#v020-rc1)**
+- **[v0.1.0 - Initial version](#v010---initial-version)**
+
+**Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
+
+The below sections record the changes in each release as follows:
+
+* for an alpha release, the delta with respect to the previous release
+* for the first release-candidate, all changes since the last public release
+* for subsequent release-candidate(s), only the delta to the previous release-candidate
+* for a public release, the consolidated changes since the previous public release
+
+# r2.1
+
+## Release Notes
+
+This pre-release contains the definition and documentation of:
+
+* "Identity and Consent Management" v0.3.0-alpha.1
+
+NOTE: The Working Group release numbering has been updated to adopt the same release notation as is used for API sub-projects.
+
+### Added
+
+* Recommend signed authentication requests for CIBA by @eric-murray in https://github.com/camaraproject/IdentityAndConsentManagement/pull/217
+* Operator token login_hint format by @AxelNennker in https://github.com/camaraproject/IdentityAndConsentManagement/pull/218
+
+### Changed
+
+* Updated the `CAMARA-Security-Interoperability.md` document to replace Telco and Operator terms with API Provider by @AxelNennker in https://github.com/camaraproject/IdentityAndConsentManagement/pull/201
+* Updated terms and definitions in the `CAMARA-API-access-and-user-consent.md` for better writing and understanding by @jpengar in https://github.com/camaraproject/IdentityAndConsentManagement/pull/212
+* Updated the `CAMARA-API-access-and-user-consent.md` document with editorial and general writing improvements by @jpengar in https://github.com/camaraproject/IdentityAndConsentManagement/pull/213
+
+### Fixed
+
+* Fixed error description for missing openid scope in the `CAMARA-Security-Interoperability.md` document by @AxelNennker in https://github.com/camaraproject/IdentityAndConsentManagement/pull/210
+* Clarify case sensitivity of parameter names and values in the `CAMARA-Security-Interoperability.md` document by @eric-murray in https://github.com/camaraproject/IdentityAndConsentManagement/pull/221
+
+### Removed
+
+N/A
+
+**Full Changelog**: https://github.com/camaraproject/IdentityAndConsentManagement/compare/r0.2.1...r2.1
 
 # r0.2.1
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ Repository to describe, develop, document and test the Identity And Consent Mana
 
 ## Release Information
 
-* `NEW`: Release 0.2.1 of the "Identity and Consent Management" guidelines and documentation for the CAMARA APIs is available under the tag [r0.2.1](https://github.com/camaraproject/IdentityAndConsentManagement/tree/r0.2.1). It contains the current version of the documents which are relevant for [Fall24 meta-release](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14549015/Meta-release+Fall24), including:
+* `NEW`: Alpha release of the "Identity and Consent Management" guidelines and documentation for the CAMARA APIs is available under the tag [r2.1](https://github.com/camaraproject/IdentityAndConsentManagement/tree/r2.1). It contains the current [version](/VERSION.yaml) of the documents which are relevant for [Spring25 meta-release](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14560849/Meta-release+Spring25), including:
+  * [CAMARA APIs access and user consent management](https://github.com/camaraproject/IdentityAndConsentManagement/blob/r2.1/documentation/CAMARA-API-access-and-user-consent.md)
+  * [CAMARA Security and Interoperability Profile](https://github.com/camaraproject/IdentityAndConsentManagement/blob/r2.1/documentation/CAMARA-Security-Interoperability.md)
+    >NOTE: the Working Group release numbering has been updated to adopt the same release notation as is used for API sub-projects.
+* Release 0.2.1 of the "Identity and Consent Management" guidelines and documentation for the CAMARA APIs is available under the tag [r0.2.1](https://github.com/camaraproject/IdentityAndConsentManagement/tree/r0.2.1). It contains the current version of the documents which are relevant for [Fall24 meta-release](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14549015/Meta-release+Fall24), including:
   * [CAMARA APIs access and user consent management](https://github.com/camaraproject/IdentityAndConsentManagement/blob/r0.2.1/documentation/CAMARA-API-access-and-user-consent.md)
-  * [Camara Security and Interoperability Profile](https://github.com/camaraproject/IdentityAndConsentManagement/blob/r0.2.1/documentation/CAMARA-Security-Interoperability.md)
+  * [CAMARA Security and Interoperability Profile](https://github.com/camaraproject/IdentityAndConsentManagement/blob/r0.2.1/documentation/CAMARA-Security-Interoperability.md)
 * The latest **public release** of guidelines and documentation for CAMARA APIs is available [here](https://github.com/camaraproject/IdentityAndConsentManagement/releases/latest).
-* For previous releases and changes see [CHANGELOG.md](https://github.com/camaraproject/IdentityAndConsentManagement/blob/main/CHANGELOG.md)
+* For previous releases and changes see [CHANGELOG.md](/CHANGELOG.md)
 
 ## Contributing
 * Meetings

--- a/VERSION.yaml
+++ b/VERSION.yaml
@@ -1,1 +1,1 @@
-version: wip
+version: v0.3.0-alpha.1

--- a/VERSION.yaml
+++ b/VERSION.yaml
@@ -1,1 +1,1 @@
-version: v0.3.0-alpha.1
+version: 0.3.0-alpha.1


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

This is the release PR for the pre-release r2.1 (first alpha release for Spring25) containing version v0.3.0-alpha.1 of ICM

#### Which issue(s) this PR fixes:

Fixes #235
Fixes #207

It is related to #193

#### Special notes for reviewers:

This PR includes all the changes in the ICM scope of the Spring25 meta-release that have been merged so far. However, there are still open discussions that will need to be included when consensus is reached.

#### Changelog input

```
r2.1 containing version v0.3.0-alpha.1 of ICM
```

#### Additional documentation 

https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14551399/Meta-release+Process#Commonalities-and-ICM
https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/14560849/Meta-release+Spring25

