### PR TITLE
Allow API to decide on network-based authentication in OIDC authorization code flow

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -100,7 +100,7 @@ Note over FE,BE: Use Feature needing<br>Operator Capability
 BE->>FE: Auth Needed - redirect <br>/authorize?response_type=code&client_id=coolApp<br>&scope=dpv:<purposeDpvValue> scope1 ... scopeN<br>&redirect_uri=invoker_callback...
 FE->>+FE: Browser /<br> Embedded Browser
 alt Standard OIDC Auth Code Flow between Invoker and API Exposure Platform
-  FE-->>ExpO: GET /authorize?response_type=code&client_id=coolApp<br>&scope=dpv:<purposeDpvValue> scope1 ... scopeN<br>&redirect_uri=invoker_callback...
+  FE-->>ExpO: GET /authorize?response_type=code&client_id=coolApp<br>&scope=dpv:<purposeDpvValue> scope1 ... scopeN<br>&acr_values=https%3A%2F%2Fcamaraproject.org%2Facr%2Fnetworkbasedauthentication<br>&redirect_uri=invoker_callback...
   Note over ExpO: API Exposure Platform applies<br>Network Based Authentication (amr=nba/mnba)
   ExpO->>ExpO: Network Based Authentication:<br>- map to Telco Identifier e.g.: phone_number<br>- Set UserId (sub)  
   ExpO->>ExpO: Check legal basis of the purpose<br> e.g.: contract, legitimate_interest, consent, etc 
@@ -136,7 +136,7 @@ As per the standard authorization code flow, the Application is redirected to th
 
 The Operator's API Exposure Platform receives the request from the Application (Step 3) and does the following:
 
-- Uses network based authentication to obtain the Subscriber's unique identifier,e.g.: phone number or IMSI. Sets the id_token sub to a unique user ID and associates the sub with the access token. The id_token sub MUST NOT reveal information to the Application, as authentication has not yet been performed. (Step 4).
+- If the parameter `acr_values=https%3A%2F%2Fcamaraproject.org%2Facr%2Fnetworkbasedauthentication` is received, then the authorization server uses network based authentication to obtain the Subscriber's unique identifier,e.g.: phone number or IMSI. Sets the id_token sub to a unique user ID and associates the sub with the access token. The id_token sub MUST NOT reveal information to the Application, as authentication has not yet been performed. (Step 4). If network-based authentication is not requested, then  the authorization server continues with the flow as defined in the OIDC standard.
 
 - Checks if User Consent is required, which depends on the legal basis associated with the Scope and Purpose. If necessary, it will check in the Operator's Consent Master whether User Consent has already been given for this Application, Scope and Purpose (Steps 5-6).
 

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -181,7 +181,7 @@ This documents defines that CAMARA OpenId Providers MUST ignore the parameter ac
 If the [OIDC Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) has the `acr_values` parameter with the value "https://camaraproject.org/acr/networkbasedauthentication" then the authorization server MUST try to identify the subscriber through network-based authentication. The [ID Token](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) returned from the token endpoint SHALL then contain an Authentication Methods References field `amr` which MUST contain the value "https://camaraproject.org/acr/networkbasedauthentication". 
 If the OIDC authentication request is not made over a connection where the API provider can do network-based authentication, then the error code of the [Authentication Error Response](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) is REQUIRED to be `400`. The error_description SHOULD be "network-based authentication was not possible".
 
-This document defines that CAMARA Clients SHOULD not send acr_values parameters with values different from `https://camaraproject.org/acr/networkbasedauthentication`. 
+This document defines that CAMARA API Consumers SHOULD not send acr_values parameters with values different from `https://camaraproject.org/acr/networkbasedauthentication`. 
 
 > To foster interoperability a future version of this document might define other values for the acr_values parameter acceptable in CAMARA.
 

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -177,13 +177,13 @@ OIDC specifies in [Mandatory to Implement Features for All OpenID Providers](htt
 
 OIDC also defines that the parameter acr_values is OPTIONAL and does not specify possible values. This leads to interoperability issues.
 
-This documents defines that Camara OpenId Providers MUST ignore the parameter acr_values with a value different from "https://camaraproject.org/acr/networkbasedauthentication".
+This documents defines that CAMARA OpenId Providers MUST ignore the parameter acr_values with a value different from "https://camaraproject.org/acr/networkbasedauthentication".
 If the [OIDC Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) has the `acr_values` parameter with the value "https://camaraproject.org/acr/networkbasedauthentication" then the authorization server MUST try to identify the subscriber through network-based authentication. The [ID Token](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) returned from the token endpoint SHALL then contain an Authentication Methods References field `amr` which MUST contain the value "https://camaraproject.org/acr/networkbasedauthentication". 
 If the OIDC authentication request is not made over a connection where the API provider can do network-based authentication, then the error code of the [Authentication Error Response](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) is REQUIRED to be `400`. The error_description SHOULD be "network-based authentication was not possible".
 
-This document defines that Camara Clients SHOULD not send acr_values parameters with values different from `https://camaraproject.org/acr/networkbasedauthentication`. 
+This document defines that CAMARA Clients SHOULD not send acr_values parameters with values different from `https://camaraproject.org/acr/networkbasedauthentication`. 
 
-> To foster interoperability a future version of this document might define other values for the acr_values parameter acceptable in Camara.
+> To foster interoperability a future version of this document might define other values for the acr_values parameter acceptable in CAMARA.
 
 ## Access Token Request
 

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -177,11 +177,13 @@ OIDC specifies in [Mandatory to Implement Features for All OpenID Providers](htt
 
 OIDC also defines that the parameter acr_values is OPTIONAL and does not specify possible values. This leads to interoperability issues.
 
-This documents defines that CAMARA OpenId Providers MUST ignore the parameter acr_values. 
+This documents defines that Camara OpenId Providers MUST ignore the parameter acr_values with a value different from `https://camaraproject.org/acr/networkbasedauthentication`.
+If the [OIDC Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) has the `àcr_values` parameter with the value `https://camaraproject.org/acr/networkbasedauthentication` then the authorization server MUST try to identify the subscriber through network-based authentication.
+If the OIDC authentication request is not made over a connection where the API provider can do network-based authentication, then the error code of the [Authentication Error Response](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) is REQUIRED to be `400`. The error_description SHOULD be "network-based authentication was not possible".
 
-This document defines that CAMARA API consumers SHOULD not use the acr_values parameter. 
+This document defines that Camara Clients SHOULD not send acr_values parameters with values different from `https://camaraproject.org/acr/networkbasedauthentication`. 
 
-> To foster interoperability a future version of this document might define values for the acr_values parameter acceptable in CAMARA.
+> To foster interoperability a future version of this document might define other values for the acr_values parameter acceptable in Camara.
 
 ## Access Token Request
 

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -177,8 +177,8 @@ OIDC specifies in [Mandatory to Implement Features for All OpenID Providers](htt
 
 OIDC also defines that the parameter acr_values is OPTIONAL and does not specify possible values. This leads to interoperability issues.
 
-This documents defines that Camara OpenId Providers MUST ignore the parameter acr_values with a value different from `https://camaraproject.org/acr/networkbasedauthentication`.
-If the [OIDC Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) has the `àcr_values` parameter with the value `https://camaraproject.org/acr/networkbasedauthentication` then the authorization server MUST try to identify the subscriber through network-based authentication.
+This documents defines that Camara OpenId Providers MUST ignore the parameter acr_values with a value different from "https://camaraproject.org/acr/networkbasedauthentication".
+If the [OIDC Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) has the `acr_values` parameter with the value "https://camaraproject.org/acr/networkbasedauthentication" then the authorization server MUST try to identify the subscriber through network-based authentication. The [ID Token](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) returned from the token endpoint SHALL then contain an Authentication Methods References field `amr` which MUST contain the value "https://camaraproject.org/acr/networkbasedauthentication". 
 If the OIDC authentication request is not made over a connection where the API provider can do network-based authentication, then the error code of the [Authentication Error Response](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) is REQUIRED to be `400`. The error_description SHOULD be "network-based authentication was not possible".
 
 This document defines that Camara Clients SHOULD not send acr_values parameters with values different from `https://camaraproject.org/acr/networkbasedauthentication`. 


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Currently CAMARA APIs have no way to specify in the [OIDC authentication request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) that the API requests network-based authentication or not. 

The OIDC standard allows the API consumer to specify the parameter `acr_values` to request [Authentication Context Class Reference values](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest:~:text=OPTIONAL.%20Requested-,Authentication%20Context%20Class%20Reference,-values.%20Space%2Dseparated).
The OIDC standard does not standardize possible values for the `acr_values` parameter.
IETF standardized some values for Authentication Method Reference Values, which are related to Authentication Context Class Reference values, in [RFC8176](https://datatracker.ietf.org/doc/html/rfc8176) but none of the standardized values match network-based authentication.

The PR defines a value https://camaraproject.org/acr/networkbasedauthentication for the OIDC acr_values parameter.

##### Example CAMARA APIs that require networkbased-authentication:
NumberVerification currently specifies in its yaml-file that it needs networkbased-authentication. 
No other API currently specifies the need for networkbased-authentication.
After this PR is merged the NumberVerification API specification can require that the API consumer sends Authentication Requests with the parameter acr_values="https://camaraproject.org/acr/networkbasedauthentication"

If the OIDC authentication request starts on the user's mobile phone, either in the API consumer's mobile application or in a browser, and the connection is "on-net", then a request with acr_values="https://camaraproject.org/acr/networkbasedauthentication" triggers network-based authentication which succeeds, regardless whether e.g. prompt=none or prompt=consent. The subscription is then identified and the flow continues with a consent-check for that subscription.

##### Benefits if the PR is merged and implemented

This PR allows the API provider to request network-based authentication.
This PR specifies one acr_values value https://camaraproject.org/acr/networkbasedauthentication. That value is also used in the returned ID Token als `amr_values` indicating whether network-based authentication was done or not.
The implementation of the authorization server's authorization code flow becomes more flexible.
Current implementations of OIDC authorization code flow become more standard.

