### PR TITLE
Remove reference to formatting and encoding of operator token values

### DIFF
--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -175,10 +175,7 @@ This CAMARA document clarifies the values used in login_hint in the following wa
 
   * **_operatortoken_**
 
-    For operator tokens as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/).
-    TS.43 does not specify the format of the operator token and it therefore might contain characters that are not url-safe.
-    The API consumer MUST encode the operator token using [base64url](https://www.rfc-editor.org/rfc/rfc7515.html#appendix-C) encoding to make it URL safe.
-    For example, `operatortoken:ZXhhbXBsZQ`
+    For operator tokens as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/). TS.43 does not specify the format of the operator token.
     
    This document does not specifiy how the API consumer got the operatorToken. 
 


### PR DESCRIPTION
#### What type of PR is this?

* documentation


#### What this PR does / why we need it:

It is not necessary to define a specific encoding format for the value of the operator token sent as login_hint in CIBA because it may contain url-unsafe characters. The standard already addresses this issue and states that all parameters must be encoded in `application/x-www-form-urlencoded`.

Any reference to the encoding of the operator token is removed, just as the other parameters that could contain url-unsafe characters are not mentioned for the same case, as this could lead to misunderstandings by sending a double-encoded parameter.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #259 
