### PR TITLE
DRAFT: Create consent-url.yaml

### DIFF
--- a/documentation/API_documentation/consent-url.yaml
+++ b/documentation/API_documentation/consent-url.yaml
@@ -1,0 +1,379 @@
+openapi: 3.0.3
+info:
+  title: Consent URL API
+  description: |
+    
+    The Consent URL API provides one endpoint that responds with the URL where the user is authenticated by the CSP and then the User's consent is managed. No personal information about the User identified by the provided phone number is provides in the response. This endpoint is therefore protected by a two-legged access token. 
+
+    # Introduction
+
+    **TBC**
+
+    # Relevant terms and definitions
+
+    * **Consent**: An explicit opt-in action that the User takes to allow processing of Personal Data. Consent grants the API Consumer access to a set of scopes related to the User for a specific Purpose.
+    * **Purpose**: The reason for which Personal Data will be processed by an API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended Personal Data processing.
+    * **TBC**: TBC
+
+    # API Functionality
+
+    This API enables an API Consumer to determine whether user Consent is required, in the applicable legislation, for the requested actions based on the provide scope(s) and Purpose. Specifically, the API:
+
+    * Determines the need for Consent: Evaluates whether user Consent is necessary according to the specified parameters and relevant legal requirements.
+    * Provides the current Consent status: If Consent is required, the API returns the current status (e.g., active, revoked, expired...) so the API Consumer can understand the current User's consent status.
+    * Offers a Consent Capture URL: If the user has not provided the necessary Consent, the API supplies an API Provider's Consent capture URL where the user can easily complete the Consent process.
+    
+    Importantly, this API does NOT delegate consent capture to the API Consumer but rather empowers the API Consumer to present the API Providers's Consent capture URL at the most opportune time and place. The actual Consent capture occurs within the API Provider's secure environment, ensuring the User's authentication with the API Provider.
+
+    **TBC**
+
+    # Authorization and authentication
+
+    The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
+
+    The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
+
+    In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
+    
+    # Further info and support
+
+    (FAQs will be added in a later version of the documentation)
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: wip
+  x-camara-commonalities: 0.5
+servers:
+  - url: '{apiRoot}/consent-url/vwip'
+    variables:
+      apiRoot:
+        default: http://localhost:9091
+        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
+tags:
+  - name: Get Consent URL
+    description: Returns a URL where the User is authenticated and their consent managed if the purpose and scope require consent management
+paths: 
+  /getConsentManagementURL:
+    post:
+      summary: Get the URL where the end-user manages their consent.
+      description: |
+        Get the URL where the end-user is authenticated and their consent for a given purpose and CAMARA API as represented by scope is managed.
+        The response does not reveal any personal information about the provided phone number nor the subscriber or end-user associated with the phone number.
+        This request is a server-to-server request authorized by client credentials (private_key_jwt).
+      operationId: getConsentURL
+      security:
+        - openId:
+          - consent-info:geturl
+      tags:
+        - Get Consent URL      
+      parameters:
+        - $ref: '#/components/parameters/x-correlator'
+      requestBody:
+        required: true
+        description:
+          Get the Consent URL
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GetConsentUrlBody"
+            example:
+              phoneNumber: "+123456789"
+              scopes:
+                - "location-retrieval:read"
+              purpose: "dpv:PersonalisedAdvertising"
+      responses:
+        "200":
+          description: OK
+          headers:
+            x-correlator:
+              $ref: '#/components/headers/x-correlator'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetConsentUrlResponseBody"
+              examples:
+                CONSENT_CAPTURE_URL_OIDC:
+                  summary: Consent capture URL is provided
+                  description: |
+                    The URL where the user is authenticated and where they can manage their consent for the provided purpose and scope(s).
+                    
+                      **Implementation note**: 
+                      * The URL MUST not be for a particular CSP.
+                      * The URL MUST not reveal any information about the provided phone number or the associated subscriber or end-user.
+                  value:
+                    captureUrl: 'https://agg.example.org/authorize?prompt=consent&scope="..."'
+                USER_CANNOT_MANAGE_CONSENT:
+                  summary: User consent cannot be managed for this purpose and requested scope(s)
+                  description: |
+                    User consent cannot be managed for this purpose and requested scope(s) e.g. legitimate-use purpose without opt-out
+                  value:
+                    consentcannotbemanaged: true
+
+                CONSENT_CAPTURE_URL_Aggregator:
+                  summary: Consent capture URL at the aggregator is provided
+                  description: |
+                    The URL where the user is authenticated and where they can manage their consent for the provided purpose and scope(s).
+                    The part <JWE> is encrypted to the aggregator who then decrypts it and redirects to the CSP without the need to use CSP-resolution services like e.g. Telco Finder.
+                    The <JWE> is different is different each time even is all the parameters are the same.
+                    The <JWE> must not be a permanent, global identifier for the User nor for the CSP.
+                  value:
+                    captureUrl: 'https://agg.example.org/consent/<JWE>'
+        "400":
+          $ref: "#/components/responses/Generic400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/verifyConsentStatus403"
+        "404":
+          $ref: "#/components/responses/Generic404"
+        "422":
+          $ref: "#/components/responses/Generic422"
+components:
+  headers:
+    x-correlator:
+      description: Correlation id for the different services
+      schema:
+        type: string
+        pattern: ^[a-zA-Z0-9-]{0,55}$
+  parameters:
+    x-correlator:
+      name: x-correlator
+      in: header
+      description: Correlation id for the different services
+      schema:
+        type: string
+        pattern: ^[a-zA-Z0-9-]{0,55}$
+        example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
+  schemas:
+    PhoneNumber:
+      type: string
+      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
+      pattern: '^\+[1-9][0-9]{4,14}$'
+      example: "+123456789" 
+    GetConsentUrlBody:
+      type: object
+      required:
+        - phoneNumber
+        - scopes
+        - purpose
+      properties:
+        phoneNumber:
+          $ref: "#/components/schemas/PhoneNumber"
+        scopes:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          description: |
+            List of scopes for which the Consent URL is requested. The scope is a string that represents the access rights that the API Consumer is requesting from the User.
+          example:
+            - "location-verification:verify"
+        purpose:
+          type: string
+          description: |
+            The reason for which Personal Data will be processed by the API Consumer. CAMARA defines a standard set of Purposes which can be used by API Consumers to specify the reason for their intended Personal Data processing.
+          example: "dpv:FraudPreventionAndDetection"
+    GetConsentUrlResponseBody:
+      type: object
+      required:
+        - consentManagementStatus
+      properties:
+        consentManagementStatus:
+          type: string
+          enum:
+            - REQUIRED
+            - OPTOUT
+            - NOTREQUIRED
+          description: |
+            Whether Consent is required or not
+              * REQUIRED - purpose and scope require consent
+              * OPTOUT - purpose and scope do not require consent but the user can opt-out
+              * NOTREQUIRED - purpose and scope do not require consent
+        captureUrl:
+          type: string
+          format: url
+          description: |
+            URL where the User can provide the necessary Consent. 
+            This field is only present when consentManagementStatus is OPTOUT or REQUIRED
+          example: 'https://agg.example.org/f79203c4-042c-4678-aa47-f690a022abc3'
+    ErrorInfo:
+      type: object
+      required:
+        - status
+        - code
+        - message
+      properties:
+        status:
+          type: integer
+          description: HTTP response status code
+        code:
+          type: string
+          description: Friendly Code to describe the error
+        message:
+          type: string
+          description: A human readable description of what the event represent
+  responses:
+    Generic400:
+      description: Bad Request
+      headers:
+        x-correlator:
+          $ref: '#/components/headers/x-correlator'
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+          examples:
+            GENERIC_400_INVALID_ARGUMENT:
+              description: Invalid Argument. Generic Syntax Exception
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: Client specified an invalid argument, request body or query param.
+    Generic401:
+      description: Unauthorized
+      headers:
+        x-correlator:
+          $ref: '#/components/headers/x-correlator'
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 401
+                  code:
+                    enum:
+                      - UNAUTHENTICATED
+          examples:
+            GENERIC_401_UNAUTHENTICATED:
+              description: Request cannot be authenticated
+              value:
+                status: 401
+                code: UNAUTHENTICATED
+                message: Request not authenticated due to missing, invalid, or expired credentials.
+    verifyConsentStatus403:
+      description: Forbidden
+      headers:
+        x-correlator:
+          $ref: '#/components/headers/x-correlator'
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 403
+                  code:
+                    enum:
+                      - PERMISSION_DENIED
+                      - CONSENT_INFO.NOT_ALLOWED_SCOPES
+                      - CONSENT_INFO.CAPTURE_FREQUENCY_EXCEEDED
+          examples:
+            GENERIC_403_PERMISSION_DENIED:
+              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
+              value:
+                status: 403
+                code: PERMISSION_DENIED
+                message: Client does not have sufficient permissions to perform this action.
+            NOT_ALLOWED_SCOPES:
+              description: The requested scope(s) and Purpose combination is not allowed for the API Consumer, e.g. the API Consumer has not onboarded the appropriate API(s) with the API Provider for the declared Purpose.
+              value:
+                status: 403
+                code: CONSENT_INFO.NOT_ALLOWED_SCOPES
+                message: The requested scope(s) and Purpose combination is not allowed for this API Consumer.
+            CAPTURE_FREQUENCY_EXCEEDED:
+              description: The frequency of consent capture requests has been exceeded.
+              value:
+                status: 403
+                code: CONSENT_INFO.CAPTURE_FREQUENCY_EXCEEDED
+                message: The frequency of consent capture requests has been exceeded. Please try again later.
+    Generic404:
+      description: Not found
+      headers:
+        x-correlator:
+          $ref: '#/components/headers/x-correlator'
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+                      - IDENTIFIER_NOT_FOUND
+          examples:
+            GENERIC_404_NOT_FOUND:
+              description: Resource is not found
+              value:
+                status: 404
+                code: NOT_FOUND
+                message: The specified resource is not found.
+            GENERIC_404_IDENTIFIER_NOT_FOUND:
+              description: Some identifier cannot be matched to a device
+              value:
+                status: 404
+                code: IDENTIFIER_NOT_FOUND
+                message: Phone number not found.
+    Generic422:
+      description: Unprocessable Content
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 422
+                  code:
+                    enum:
+                      - SERVICE_NOT_APPLICABLE
+                      - MISSING_IDENTIFIER
+                      - UNNECESSARY_IDENTIFIER
+          examples:
+            GENERIC_422_SERVICE_NOT_APPLICABLE:
+              description: Service not applicable for the provided identifier
+              value:
+                status: 422
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not available for the provided phone number.
+            GENERIC_422_MISSING_IDENTIFIER:
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
+              value:
+                status: 422
+                code: MISSING_IDENTIFIER
+                message: The phone number cannot be identified.
+            GENERIC_422_UNNECESSARY_IDENTIFIER:
+              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
+              value:
+                status: 422
+                code: UNNECESSARY_IDENTIFIER
+                message: The phone number is already identified by the access token.
+  securitySchemes:
+    openId:
+      type: openIdConnect
+      openIdConnectUrl: https://example.org/.well-known/openid-configuration


### PR DESCRIPTION
Separate the Consent URL API OpenAPI definition from the consent-info.yaml file into its own yaml file.

Make it clear that API is protected by a two-legged access token and why this possible if certain implementation requirements are met - no personal information is processes although a phone number is provided.


#### What type of PR is this?
* documentation


#### What this PR does / why we need it:
Separate Consent URL API from Consent Info API.

#### Which issue(s) this PR fixes:

#### Additional documentation 

Related to:
https://github.com/camaraproject/IdentityAndConsentManagement/issues/224
https://github.com/camaraproject/IdentityAndConsentManagement/pull/266
