### PR TITLE
Further alignment of CAMARA-API-access-and-user-consent.md with CAMARA terms and definitions

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -157,8 +157,6 @@ The Operator's API Exposure Platform will validate OperatorAccessToken, grant th
 
 Finally, the Operator will provide the API response to the Application (Step 15).
 
-<br>
-
 ##### Technical ruleset for the Frontend flow
 
 _NOTE: The technical ruleset is applicable only after a subproject has agreed to use a Three-Legged Access Token authentication flow. This ruleset provides a recommendation which will help API providers to align on the Three-Legged Access Token Flow and help with aggregation._

--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -100,7 +100,7 @@ FE->>+FE: Browser /<br> Embedded Browser
 alt Standard OIDC Auth Code Flow between API Consumer and API Exposure Platform
   FE-->>ExpO: GET /authorize?response_type=code&client_id=coolApp<br>&scope=dpv:<purposeDpvValue> scope1 ... scopeN<br>&redirect_uri=consumer_callback...
   Note over ExpO: API Exposure Platform applies<br>Network Based Authentication (amr=nba/mnba)
-  ExpO->>ExpO: Network Based Authentication:<br>- map to Operator subscription Identifier e.g.: phone_number<br>- Set UserId (sub)  
+  ExpO->>ExpO: Network Based Authentication:<br>- map to Operator subscription Identifier e.g.: phone number<br>- Set UserId (sub)  
   ExpO->>ExpO: Check legal basis of the purpose<br> e.g.: contract, legitimate_interest, consent, etc 
   opt If User Consent is required for the legal basis of the purpose  
     ExpO->>Consent: Check if Consent is granted    

--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -6,12 +6,14 @@ This document defines guidelines for API Providers to manage CAMARA API access a
 
 - [Introduction](#introduction)
 - [Glossary of Terms and Concepts](#glossary-of-terms-and-concepts)
-- [Purpose within Camara](#purpose-within-camara)
+- [Purpose within CAMARA](#purpose-within-camara)
   - [Using Purpose within the authorization request](#using-purpose-within-the-authorization-request)
 - [User Authentication/Authorization \& Consent Management](#user-authenticationauthorization--consent-management)
   - [Authorization flows / grant types](#authorization-flows--grant-types)
-    - [Authorization code flow (Frontend flow)](#authorization-code-flow-frontend-flow)
+    - [Authorization Code Flow (Frontend Flow)](#authorization-code-flow-frontend-flow)
+      - [Technical ruleset for the Frontend flow](#technical-ruleset-for-the-frontend-flow)
     - [CIBA flow (Backend flow)](#ciba-flow-backend-flow)
+      - [Technical ruleset for the Backend flow](#technical-ruleset-for-the-backend-flow)
     - [Client Credentials](#client-credentials)
 - [CAMARA API Specification - Authorization and authentication common guidelines](#camara-api-specification---authorization-and-authentication-common-guidelines)
   - [Use of openIdConnect for `securitySchemes`](#use-of-openidconnect-for-securityschemes)
@@ -157,7 +159,7 @@ Finally, the Operator will provide the API response to the Application (Step 15)
 
 <br>
 
-**Technical ruleset for the Frontend flow**
+##### Technical ruleset for the Frontend flow
 
 _NOTE: The technical ruleset is applicable only after a subproject has agreed to use a Three-Legged Access Token authentication flow. This ruleset provides a recommendation which will help API providers to align on the Three-Legged Access Token Flow and help with aggregation._
 
@@ -265,7 +267,7 @@ Finally, the Operator will validate the OperatorAccessToken, grant access to the
 
 The Operator will provide the API response to the API Consumer (Step 11).
 
-**Technical ruleset for the Backend flow**
+##### Technical ruleset for the Backend flow
 
 _NOTE: The technical ruleset is applicable only after a subproject has agreed to use a Three-Legged Access Token authentication flow. This ruleset is a recommendation which will help Operators align on the Three-Legged Access Token and help with aggregation._ 
 


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Update `CAMARA-API-access-and-user-consent.md` to achieve further alignment in the use of the terms "API Consumer" and "API Provider" (replacing other potential synonyms used) and to avoid the term "Telco" which has been reported in the past. 

Changes included:

- Replace "API Invoker" with "API Consumer".
- Remove mentions of the term "Telco".
- Include the term "API Provider" replacing others when applicable/possible.

**NOTE: These changes will be only naming/wording changes and no technical information in the specification document is changed**

#### Which issue(s) this PR fixes:

Fixes #279 

#### Special notes for reviewers:

**The term "Operator" has not been completely replaced by "API Provider", instead "Operator" is still used as the main and most common use case of "API Provider". In my opinion, trying to remove all references to the term "Operator" makes no sense and would require a much deeper document refactoring that I don't think is necessary.**

#### Changelog input

```
 CAMARA-API-access-and-user-consent.md update for further alignment with CAMARA terms and definitions
```

#### Additional documentation 

N/A
