### PR TITLE
JWT Bearer Flow

### DIFF
--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -22,6 +22,7 @@
     * [Refresh Token Usage](#refresh-token-usage)
     * [Refresh Token Security](#refresh-token-security)
   * [Client Credentials Flow](#client-credentials-flow)
+  * [JWT Bearer Flow](#jwt-bearer-flow)
   * [Handling of acr_values](#handling-of-acr_values)
   * [Access Token Request](#access-token-request)
   * [The Scope Parameter](#the-scope-parameter)
@@ -226,6 +227,31 @@ Considering [OAuth2 Refresh Token Protection](https://datatracker.ietf.org/doc/h
 ## Client Credentials Flow
 
 The [OAuth 2.0 Client Credentials](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) grant type is used to obtain a 2-legged Access Token that does not represent a user. The grant-type can only be used if agreed between the API consumer and the API provider exposing the API, taking into account the declared purpose for accessing the API (cf. [CAMARA API Specification - Authorization and authentication common guidelines](CAMARA-API-access-and-user-consent.md#camara-api-specification---authorization-and-authentication-common-guidelines)).
+
+## JWT Bearer Flow
+
+The JWT-Bearer Flow uses [JWTs as Authorization Grants](https://datatracker.ietf.org/doc/html/rfc7523#section-2.1) ("urn:ietf:params:oauth:grant-type:jwt-bearer" grant_type for Oauth 2.0) that provide a JWT assertion following the OAuth Assertion Framework: [Using Assertions as Authorization Grants](https://datatracker.ietf.org/doc/html/rfc7521#section-4.1) | [Client Acting on Behalf of a User](https://datatracker.ietf.org/doc/html/rfc7521#section-6.3).
+
+The scope parameter is MUST not be specified for JWT-Bearer Flow but the scope claim in the assertion is mandatory. 
+
+The claim of the assertion are.
+
+- The mandatory `iss` claim MUST be the client id of the API Consumer.
+- The mandatory `sub` (subject) claim MUST identifies the principal that is the subject of the JWT.
+  -  The value MUST be either a phonenumber prefixed by "tel:" or a TS.43 token prefixed by "operatortoken:".
+- The mandatory `aud` claim MUST be the URL of the endpoint this token request is sent to.
+- The mandatory `exp` claim as defined in [RFC7519 section 4.1.4](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.4).
+- The mandatory `iat` claim as defined in [RFC7519 section 4.1.6](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.6).
+- The mandatory `jti` claim as defined in [RFC7519 section 4.1.7](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.7).
+- The mandatory `scope` claim that MUST contain a [Purpose](#purpose) and CAMARA scope values. 
+
+Client Authentication is optional for JWT-Bearer Flow and is not needed in this CAMARA token request because the assertion is signed by the API Consumer and the assertion is interpreted as the client assertion.
+
+The request SHALL be rejected by the authorisation server if the exp claim is more than 300 seconds later than the time of receipt. Additionally, if the iat claim is present, the request SHALL be rejected if the difference between the exp claim and iat claim is more than 300 seconds.
+
+This flow SHOULD return short-lived access tokens.
+
+This flow MUST not return refresh tokens.
 
 ## Handling of acr_values
 


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:
In legitimate use use case we need a flow that allows the API Consumer to specify the subject (User) of the request.
This JWT Bearer Flow is a two-legged flow that returns a three-legged token.

#### Which issue(s) this PR fixes:
Fixes #277 
