### PR TITLE
Clarify what the values for "operatortoken" can be

### DIFF
--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -179,9 +179,9 @@ This CAMARA document clarifies the values used in login_hint in the following wa
 
   * **_operatortoken_**
 
-    For operator tokens as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/). TS.43 does not specify the format of the operator token.
+    For TS.43 tokens as defined by [GSMA TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/) and [GSMA ASAC](https://www.gsma.com/newsroom/gsma_resources/asac-01-v1-0/). TS.43 does not specify the format of the token.
     
-   This document does not specifiy how the API consumer got the operatorToken. 
+   This document does not specifiy how the API consumer got the TS.43 token. 
 
 ## Offline Access
 


### PR DESCRIPTION
#### What type of PR is this?

* documentation


#### What this PR does / why we need it:
Clarify that the value of the "operatortoken" is a token created by the Operator, usually by the operator's Entitlement Server.
This value may an TS.43 operator token as defined in TS.43 v12 section 14 "Device App Authentication" or a Temporary Token also defined in [GSMS TS.43](https://www.gsma.com/newsroom/gsma_resources/ts-43-service-entitlement-configuration/).



#### Which issue(s) this PR fixes:

Fixes #296 

#### Changelog input

```
 release-note

```

#### Additional documentation 


```
docs

```
