### PR TITLE
client assertion audience clarification for CIBA

### DIFF
--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -376,8 +376,7 @@ The API Consumer MUST NOT create client assertions with a lifetime of more than 
 
 The request SHALL be rejected by the Authorization server if the `exp` claim is more than 300 seconds later than the time of receipt. Additionally, if the `iat` claim is present, the request SHALL be rejected if the difference between the `exp` claim and `iat` claim is more than 300 seconds.
 
-This document RECOMMENDS that for [OIDC Authorization Code Flow](https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth) and [OAuth2 Client Credentials Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) the audience SHOULD be the URL of the Authorization Server's [Token Endpoint](https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint).
-This document RECOMMENDS that for OIDC CIBA the audience SHOULD be the [Backchannel Authentication Endpoint](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#auth_backchannel_endpoint).
+This document RECOMMENDS that the `aud` (audience) claim in the client assertion SHOULD contain the full URL of the specific endpoint at the Authorization Server to which the client is sending the request. For example, the Token Endpoint URL for requests to `/token`, or the [Backchannel Authentication Endpoint](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#auth_backchannel_endpoint) URL for OIDC CIBA requests to `/bc-authorize`.
 
 ## OpenId Foundation Certification
 

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -376,7 +376,7 @@ The API Consumer MUST NOT create client assertions with a lifetime of more than 
 
 The request SHALL be rejected by the Authorization server if the `exp` claim is more than 300 seconds later than the time of receipt. Additionally, if the `iat` claim is present, the request SHALL be rejected if the difference between the `exp` claim and `iat` claim is more than 300 seconds.
 
-This document RECOMMENDS that the `aud` (audience) claim in the client assertion SHOULD contain the full URL of the specific endpoint at the Authorization Server to which the client is sending the request. For example, the Token Endpoint URL for requests to `/token`, or the [Backchannel Authentication Endpoint](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#auth_backchannel_endpoint) URL for OIDC CIBA requests to `/bc-authorize`.
+This document RECOMMENDS that the `aud` (audience) claim in the client assertion SHOULD be the full URL of the specific endpoint at the Authorization Server to which the client is sending the request.
 
 ## OpenId Foundation Certification
 


### PR DESCRIPTION
#### What type of PR is this?

* correction
* documentation

#### What this PR does / why we need it:

At Telefónica, several partners have already raised questions about what aud value CAMARA recommends to use for the /bc-authorize request versus the /token request in the CIBA flow. 

The goal is simply to improve the documentation to make it more explicit without changing the current CAMARA recommendations.

The ICM working group could then consider this PR for the Fall25 meta-release, i.e. to add it before the public release.

#### Which issue(s) this PR fixes:

Fixes #301

#### Special notes for reviewers:

N/A

#### Changelog input

```
 client assertion audience clarification
```

#### Additional documentation 

N/A
