### PR TITLE
Future Adoption of OAuth 2.1

### DIFF
--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -60,6 +60,12 @@ The CAMARA document sharpens the following for interoperability and security:
 
 By encapsulating these elements within this document, it aims to provide a comprehensive guide for API consumers and API providers, ensuring consistent implementation and adherence to standardized security measures across the CAMARA ecosystem. The defined OIDC profile not only facilitates the integration process, but also serves as a basic framework for developers wishing to leverage the CAMARA APIs while maintaining security and interoperability.
 
+**Future Adoption of OAuth 2.1**
+
+The CAMARA Security and Interoperability Profile is currently based on OAuth 2.0. [OAuth 2.1](https://datatracker.ietf.org/doc/draft-ietf-oauth-v2-1/) is an in-progress effort to create an updated version that consolidates various RFCs and best practices from OAuth 2.0, while removing insecure features.
+
+CAMARA is already closely aligned with the principles of OAuth 2.1. Most of the required features are either already in place or strongly recommended. Future releases of this profile document will fully adopt the finalised OAuth 2.1 specification.
+
 
 ## Audience
 

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -64,7 +64,7 @@ By encapsulating these elements within this document, it aims to provide a compr
 
 The CAMARA Security and Interoperability Profile is currently based on OAuth 2.0. [OAuth 2.1](https://datatracker.ietf.org/doc/draft-ietf-oauth-v2-1/) is an in-progress effort to create an updated version that consolidates various RFCs and best practices from OAuth 2.0, while removing insecure features.
 
-CAMARA is already closely aligned with the principles of OAuth 2.1. Most of the required features are either already in place or strongly recommended. Future releases of this profile document will fully adopt the finalised OAuth 2.1 specification.
+CAMARA is already closely aligned with the principles of OAuth 2.1. Most of the required features are either already in place or recommended. Future releases of this profile document will fully adopt the finalised OAuth 2.1 specification.
 
 
 ## Audience


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Enhance the current the current Security Profile with a note that CAMARA will adopt OAuth 2.1 in an upcoming version as soon OAuth 2.1 gets finalized.

Discussed and agreed in https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/170721352/2025-07-16+ICM+Minutes+Draft+Agenda & https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/170917904/2025-07-17+TSC+Minutes

The ICM working group could then consider this PR for the Fall25 meta-release, i.e. to add it before the public release.

#### Which issue(s) this PR fixes:

Related to #288 

#### Special notes for reviewers:

N/A

#### Changelog input

```
Future adoption of OAuth 2.1
```

#### Additional documentation 

https://github.com/camaraproject/IdentityAndConsentManagement/issues/288
