### PR TITLE
Add openid in scope accessanduser

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -151,7 +151,7 @@ The Operator's API Exposure Platform receives the request from the Application (
 
 - Uses network based authentication to obtain the Subscriber's unique identifier,e.g.: phone number or IMSI. Sets the id_token sub to a unique user ID and associates the sub with the access token. The id_token sub MUST NOT reveal information to the Application, as authentication has not yet been performed. (Step 4).
 
-- Checks if User Consent is required, which depends on the legal basis associated with the  and Purpose. If necessary, it will check in the Operator's Consent Master whether User Consent has already been given for this Application,  and Purpose (Steps 5-6).
+- Checks if User Consent is required, which depends on the legal basis associated with the scope and Purpose. If necessary, it will check in the Operator's Consent Master whether User Consent has already been given for this Application,  and Purpose (Steps 5-6).
 
 Then, two alternatives may occur:
 


### PR DESCRIPTION
#### What type of PR is this?

correction of scope in [Acces and user consent](https://github.com/camaraproject/IdentityAndConsentManagement/blob/038e74843c76f8e31b3512d2adea7ee134cdc187/documentation/CAMARA-API-access-and-user-consent.md?plain=1) : Add openid as already present in the [examples](https://github.com/camaraproject/IdentityAndConsentManagement/blob/038e74843c76f8e31b3512d2adea7ee134cdc187/documentation/CAMARA-ICM-examples.md)


#### What this PR does / why we need it:

For consistency issue between the examples page and the access and user consent page.



#### Special notes for reviewers:



#### Changelog input


#### Additional documentation 

