### PR TITLE
Fixed jwt grant type flow typo in CAMARA-API-access-and-user-consent.md

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -403,7 +403,6 @@ Example JWT assertion, which MUST be signed by the API Consumer and MAY be encry
 
 The API Consumer sends a POST request to the API Exposure Platform's token endpoint (Step 1), using the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type and including the signed JWT assertion. The assertion contains the required claims: `iss` (client_id), `sub` (Identifying the User; the presence of a TS.43 Operator Token confirms the Subscriber's prior authentication.), `aud` (token endpoint URL), `exp`, `iat`, `jti`, and `scope` (including the declared Purpose and CAMARA scopes).
 
-
 Example Token Request:
 
 ```


### PR DESCRIPTION


#### What type of PR is this?


* correction


#### What this PR does / why we need it:

Fixes "openid" typo in scope for jwt bearer token flow


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #329 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
