### PR TITLE
High-level example of the JWT bearer flow with an operator token

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -310,7 +310,7 @@ box API Provider / Operator
 end
 
 Note over FE,BE: Feature needing<br>Operator capability  
-Note over BE: API Consumer obtains a temporary token<br>following TS.43 definitions...  
+Note over FE,BE: API Consumer obtains a temporary token<br>following TS.43 definitions...  
 
 alt OIDC Client-Initiated Backchannel Authentication (CIBA) Flow between API Consumer and Operator.
   BE->>+ExpO: POST /bc-authorize<br>Credentials,<br>scope=openid dpv:<purposeDpvValue> scope1 ... scopeN,<br>login_hint=operatortoken:<temporaryToken>    
@@ -360,7 +360,7 @@ box API Provider / Operator
   participant ExpO as API Exposure Platform  
   participant Consent as Consent Master
 end
-Note over BE,ExpO: Pre-requisite:<br> To verify the signed JWT assertion, the public key of the API Consumer must be shared<br> with API Provider as part of API Consumer's Application onboarding process
+Note over BE,ExpO: Pre-requisite:<br> To verify the signed JWT assertion, the public key of the API Consumer<br>must be shared with API Provider as part of<br>API Consumer's Application onboarding process
 Note over FE,BE: Feature needing Operator capability  
 Note over BE: Select User Identifier:<br> Phone Number / Operator Token
 
@@ -462,9 +462,9 @@ box API Provider / Operator
   participant ES as Entitlement Server  
   participant Consent as Consent Master
 end
-Note over BE,ExpO: Pre-requisite:<br> To verify the signed JWT assertion, the public key of the API Consumer must be shared<br> with API Provider as part of API Consumer's Application onboarding process
+Note over BE,ExpO: Pre-requisite:<br> To verify the signed JWT assertion, the public key of the API Consumer<br>must be shared with API Provider as part of<br>API Consumer's Application onboarding process
 Note over FE,BE: Feature needing Operator capability  
-Note over BE: API Consumer obtains a temporary token<br>following TS.43 definitions...
+Note over FE,BE: API Consumer obtains a temporary token<br>following TS.43 definitions...
 alt Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants
     BE->>+ExpO: POST /token<br>grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer<br>assertion=<br>{dpv:<purposeDpvValue> scope1 ... scopeN<br>sub=operatortoken:<temporaryToken>,...}
     ExpO->>ExpO: Validate Authentication<br>request

--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -278,14 +278,7 @@ Note over FE,BE: API Consumer obtains a temporary token<br>following TS.43 defin
 alt OIDC Client-Initiated Backchannel Authentication (CIBA) Flow between API Consumer and Operator.
   BE->>+ExpO: POST /bc-authorize<br>Credentials,<br>scope=openid dpv:<purposeDpvValue> scope1 ... scopeN,<br>login_hint=operatortoken:<temporaryToken>    
   ExpO->>ExpO: Validate Authentication<br>request
-  alt TS.43
-    Note over ExpO,ES: Get information from Entitlement Server<br> needed for access_token creation<br>Scopes are adapted
-    ExpO->>ES: AcquireOperatorToken(ap2015,temporary_token=temporaryToken,<br>operation_targets=GetSubscriberDeviceInfo,[client_id, access_token,scope="MSISDN"]) 
-    ES->>ES: Validate temporary token
-    ES->>ExpO: HTTP 200 OK <br>{operator_token}
-    ExpO->>ES: GetSubscriberDeviceInfo (ap2015, operator_token) 
-    ES->>ExpO: SubscriberDeviceInfo (MSISDN[,IMSI])
-  end
+  Note over ExpO,ES: TS.43 internal steps<br>for validating the temporary<br>token and retrieving subscriber<br>info (e.g. MSISDN) may depend<br>on API Provider's implementation<br>and are beyond the scope of<br>this document.
   ExpO->>ExpO: Check legal basis of the purpose<br> e.g.: contract, legitimate_interest, consent, etc
   opt If User Consent is required for the legal basis of the purpose  
     ExpO->>Consent: Check if Consent is granted
@@ -300,7 +293,7 @@ ExpO->>BE: CAMARA API Response
 Note over BE,FE: Response
 ```
 
-Note: The interaction between the API Exposure Platform (Authentication Server) and the Entitlement Server is just an illustrative example, not a normative one. The Entitlement Server MUST validate the temporary token when performing a TS.43 operation like GetPhoneNumber, VerifyPhoneNumber, GetSubscriberDeviceInfo or AcquireOperatorToken. 
+Note: The interaction between the API Exposure Platform (Authentication Server) and the Entitlement Server shown above is illustrative only, not normative. Regardless of the internal flow, the Entitlement Server MUST validate the temporary token when performing a TS.43 operation like GetPhoneNumber, VerifyPhoneNumber, GetSubscriberDeviceInfo or AcquireOperatorToken according to TS.43 standard.
 
 The above flow example assumes a use case where Consent is not required, such as legitimate interest. In this case, the Operator Token is used for 'silent' authentication of the User (i.e. with no User interaction), where the API Consumer has already obtained the temporary token from the Entitlement Server using EAP-AKA SIM-based authentication, which is transparent to the User.
 
@@ -413,14 +406,7 @@ Note over FE,BE: API Consumer obtains a temporary token<br>following TS.43 defin
 alt Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants
     BE->>+ExpO: POST /token<br>grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer<br>assertion=<br>{dpv:<purposeDpvValue> scope1 ... scopeN<br>sub=operatortoken:<temporaryToken>,...}
     ExpO->>ExpO: Validate Authentication<br>request
-    alt TS.43
-      Note over ExpO,ES: Get information from Entitlement Server<br> needed for access_token creation<br>Scopes are adapted
-      ExpO->>ES: AcquireOperatorToken(ap2015,temporary_token=temporaryToken,<br>operation_targets=GetSubscriberDeviceInfo,[client_id, access_token,scope="MSISDN"]) 
-      ES->>ES: Validate temporary token
-      ES->>ExpO: HTTP 200 OK <br>{operator_token}
-      ExpO->>ES: GetSubscriberDeviceInfo (ap2015, operator_token) 
-      ES->>ExpO: SubscriberDeviceInfo (MSISDN[,IMSI])
-    end
+    Note over ExpO,ES: TS.43 internal steps<br>for validating the temporary<br>token and retrieving subscriber<br>info (e.g. MSISDN) may depend<br>on API Provider's implementation<br>and are beyond the scope of<br>this document.
     ExpO->>ExpO: Check legal basis of the purpose<br> e.g.: contract, legitimate_interest, consent, etc
     opt If User Consent is required for the legal basis of the purpose  
         ExpO->>Consent: Check if Consent is granted
@@ -434,7 +420,7 @@ ExpO->>BE: CAMARA API Response
 Note over BE,FE: Response
 ```
 
-Note: The interaction between the API Exposure Platform (Authentication Server) and the Entitlement Server is just an illustrative example, not a normative one. The Entitlement Server MUST validate the temporary token when performing a TS.43 operation like GetPhoneNumber, VerifyPhoneNumber, GetSubscriberDeviceInfo or AcquireOperatorToken.
+Note: The interaction between the API Exposure Platform (Authentication Server) and the Entitlement Server shown above is illustrative only, not normative. Regardless of the internal flow, the Entitlement Server MUST validate the temporary token when performing a TS.43 operation like GetPhoneNumber, VerifyPhoneNumber, GetSubscriberDeviceInfo or AcquireOperatorToken according to TS.43 standard.
 
 ## CAMARA API Specification - Authorization and authentication common guidelines
 

--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -18,6 +18,7 @@ This document defines guidelines for API Providers to manage CAMARA API access a
     - [Client Credentials](#client-credentials)
     - [JWT Bearer Flow](#jwt-bearer-flow)
       - [Technical ruleset for the JWT Bearer Flow](#technical-ruleset-for-the-jwt-bearer-flow)
+      - [JWT Bearer flow with Operator Token](#jwt-bearer-flow-with-operator-token)
 - [CAMARA API Specification - Authorization and authentication common guidelines](#camara-api-specification---authorization-and-authentication-common-guidelines)
   - [Use of openIdConnect for `securitySchemes`](#use-of-openidconnect-for-securityschemes)
   - [Use of `security` property](#use-of-security-property)


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

This pull request adds a new section describing the JWT Bearer flow with Operator Token, including a sequence diagram and explanatory notes. This section outlines how the `sub` claim in the JWT assertion is set to the Operator Token and describes the interactions between the involved components.

#### Which issue(s) this PR fixes:

Fixes #326

#### Special notes for reviewers:

This pull request does not include the `openid` scope in the example sequence diagram (typo reported in issue #329 by @shilpa-padgaonkar)

#### Changelog input

```
 JWT bearer flow with Operator token
```

#### Additional documentation 

N/A
