### PR TITLE
Remove Rich Authorization Request (RAR) references from ICM doc

### DIFF
--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -30,7 +30,6 @@
   * [Missing "openid" scope](#missing-openid-scope)
   * [Purpose](#purpose)
     * [Purpose as a scope](#purpose-as-a-scope)
-    * [Outlook on purpose-handling leveraging Rich Authorization Request](#outlook-on-purpose-handling-leveraging-rich-authorization-request)
   * [ID Token](#id-token)
     * [ID Token sub claim](#id-token-sub-claim)
   * [Client Authentication](#client-authentication)
@@ -387,14 +386,6 @@ Purpose is one of the scope parameter's values. There MUST be exactly one purpos
 The Authorization Server identifies the purpose using the prefix `dpv:`.
 
 This scope MUST have the following format: `dpv:<dpvValue>` where `<dpvValue>` is coming from [W3C DPV purpose definition](https://w3c.github.io/dpv/2.0/dpv/#vocab-purposes)
-
-
-
-### Outlook on purpose-handling leveraging Rich Authorization Request
-
-[RFC 9396 OAuth 2.0 Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396) defines a OAuth2 parameter `authorization_details` that is used to carry fine-grained authorization data. The parameter `authorization_details` can be used in all places where OAuth2 allows the `scope` parameter. That means that the parameter `authorization_details` can be used in all places where OIDC and CIBA allow the `scope` parameter.
-
-Further format discussion will happen, e.g. how to handle multiple purposess, before the current purpose handling will be extended by using the RAR format.
 
 ## ID Token
 


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

As discussed at the last [ICM](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/482902083/2026-01-14+ICM+Minutes) and [TSC](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/477429771/2026-01-15+TSC+Minutes) meetings, if the Working Group (WG) decides to remove RAR support from the ICM Spring26 scope, this PR deletes the "[Outlook on Purpose-Handling Leveraging Rich Authorization Request](https://github.com/camaraproject/IdentityAndConsentManagement/blob/main/documentation/CAMARA-Security-Interoperability.md#outlook-on-purpose-handling-leveraging-rich-authorization-request)" section from the ICM profile. This is the only reference to RAR in the ICM documentation.

#### Which issue(s) this PR fixes:

Fixes #312
Fixes #165

#### Special notes for reviewers:

This PR will initially be kept in draft until the ICM WG makes a final decision about RAR.

#### Changelog input

```
RAR references deletion
```

#### Additional documentation 

N/A
