### PR TITLE
Security Considerations regarding audience values

### DIFF
--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -33,6 +33,7 @@
   * [ID Token](#id-token)
     * [ID Token sub claim](#id-token-sub-claim)
   * [Client Authentication](#client-authentication)
+  * [Security Considerations](#security-considerations)
   * [OpenId Foundation Certification](#openid-foundation-certification)
   * [References](#references)
   * [Appendix A (Normative): Error Responses](#appendix-a-normative-error-responses)
@@ -418,6 +419,15 @@ The API Consumer MUST NOT create client assertions with a lifetime of more than 
 The request SHALL be rejected by the Authorization server if the `exp` claim is more than 300 seconds later than the time of receipt. Additionally, if the `iat` claim is present, the request SHALL be rejected if the difference between the `exp` claim and `iat` claim is more than 300 seconds.
 
 This document RECOMMENDS that the `aud` (audience) claim in the client assertion SHOULD be the full URL of the specific endpoint at the Authorization Server to which the client is sending the request.
+
+## Security Considerations
+
+IETF and [OpenId Foundation](https://openid.net/wp-content/uploads/2025/01/OIDF-Responsible-Disclosure-Notice-on-Security-Vulnerability-for-private_key_jwt.pdf) were made aware of a potential security vulnerability regarding audience values in `private_key_jwt` and client assertions as e.g. used in JWT Bearer Flow.
+
+Analysis done by the ICM working group lead us to the conclusion that CAMARA protocols are not vulnerable because the endpoint URLs used as `audience` values are conveyed to the API consumer using TMForum APIs or out-of-band.
+Therefore audience values are valid and can be trusted.
+
+After IETF and OpenId Foundation have updated their RFCs and specifications ICM will revisit this issue.
 
 ## OpenId Foundation Certification
 

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -422,7 +422,7 @@ This document RECOMMENDS that the `aud` (audience) claim in the client assertion
 
 ## Security Considerations
 
-IETF and [OpenId Foundation](https://openid.net/wp-content/uploads/2025/01/OIDF-Responsible-Disclosure-Notice-on-Security-Vulnerability-for-private_key_jwt.pdf) were made aware of a potential security vulnerability regarding audience values in `private_key_jwt` and client assertions as e.g. used in JWT Bearer Flow.
+The IETF and the [OpenID Foundation](https://openid.net/wp-content/uploads/2025/01/OIDF-Responsible-Disclosure-Notice-on-Security-Vulnerability-for-private_key_jwt.pdf) were made aware of a potential security vulnerability regarding audience values in `private_key_jwt` and client assertions as e.g. used in JWT Bearer Flow.
 
 Analysis done by the ICM working group lead us to the conclusion that CAMARA protocols are not vulnerable because the endpoint URLs used as `audience` values are conveyed to the API consumer using TMForum APIs or out-of-band.
 Therefore audience values are valid and can be trusted.

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -424,10 +424,9 @@ This document RECOMMENDS that the `aud` (audience) claim in the client assertion
 
 The IETF and the [OpenID Foundation](https://openid.net/wp-content/uploads/2025/01/OIDF-Responsible-Disclosure-Notice-on-Security-Vulnerability-for-private_key_jwt.pdf) were made aware of a potential security vulnerability regarding audience values in `private_key_jwt` and client assertions as e.g. used in JWT Bearer Flow.
 
-Analysis done by the ICM working group lead us to the conclusion that CAMARA protocols are not vulnerable because the endpoint URLs used as `audience` values are conveyed to the API consumer using TMForum APIs or out-of-band.
-Therefore audience values are valid and can be trusted.
+Analysis done by the ICM working group led us to conclude that CAMARA protocols are not vulnerable because the endpoint URLs used as `audience` values are conveyed to API consumers via TMForum APIs or out-of-band. Therefore, `audience` values are valid and can be trusted.
 
-After IETF and OpenId Foundation have updated their RFCs and specifications ICM will revisit this issue.
+After the IETF and the OpenID Foundation update their RFCs and specifications, the ICM working group will revisit this issue.
 
 ## OpenId Foundation Certification
 


### PR DESCRIPTION
#### What type of PR is this?

* documentation


#### What this PR does / why we need it:
ICM feels that we should document our analysis of a potential security vulnerablity regarding audience values in private_key_jwt and client assertions used in JWT Bearer Flow.

It is our analysis that CAMARA is not vulnerable.


#### Which issue(s) this PR fixes:

Related to #340 

#### Changelog input

```
Added security considrations on a potential vulnerability regarding audience values used in private_key_jwt and client assertions.

```

