### PR TITLE
Update DPV references in ICM doc

### DIFF
--- a/documentation/CAMARA-API-access-and-user-consent.md
+++ b/documentation/CAMARA-API-access-and-user-consent.md
@@ -74,7 +74,7 @@ The list below introduces several key concepts:
 
 ## Purpose within CAMARA
 
-The Purpose definition (naming + description) and format within CAMARA follows the W3C [Data Privacy Vocabulary](https://w3c.github.io/dpv/)​ (DPV).
+The Purpose definition (naming + description) and format within CAMARA follows the W3C [Data Privacy Vocabulary](https://w3c.github.io/dpv/2.3/dpv/modules/purposes)​ (DPV).
 
 ### Using Purpose within the authorization request
 

--- a/documentation/CAMARA-Security-Interoperability.md
+++ b/documentation/CAMARA-Security-Interoperability.md
@@ -387,7 +387,7 @@ Purpose is one of the scope parameter's values. There MUST be exactly one purpos
 
 The Authorization Server identifies the purpose using the prefix `dpv:`.
 
-This scope MUST have the following format: `dpv:<dpvValue>` where `<dpvValue>` is coming from [W3C DPV purpose definition](https://w3c.github.io/dpv/2.0/dpv/#vocab-purposes)
+This scope MUST have the following format: `dpv:<dpvValue>` where `<dpvValue>` is coming from [W3C DPV purpose definition](https://w3c.github.io/dpv/2.3/dpv/modules/purposes)
 
 ## ID Token
 
@@ -434,7 +434,7 @@ CAMARA recommends that implementations run the OIDF interoperability suite and a
 
 ## References
 
-* [Data Privacy Vocabulary (DPV)](https://w3c.github.io/dpv/2.0/dpv/)
+* [Data Privacy Vocabulary (DPV)](https://w3c.github.io/dpv/2.3/dpv/)
 * [E.164 - The international public telecommunication numbering plan](https://www.itu.int/rec/T-REC-E.164-201011-I/en)
 * [OpenID Connect Core 1.0 specification](https://openid.net/specs/openid-connect-core-1_0.html)
 * [OpenID Connect Client-Initiated Backchannel Authentication Flow - Core 1.0](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html)


### PR DESCRIPTION
#### What type of PR is this?

* correction
* documentation

#### What this PR does / why we need it:

This pull request updates references to the W3C Data Privacy Vocabulary (DPV) throughout the documentation to point to the latest version (2.3). This ensures that all links and references are consistent and direct users to the most current definitions and modules.

**Documentation updates for DPV references:**

* Updated the link to the W3C DPV Purposes module in `CAMARA-API-access-and-user-consent.md` to use version 2.3.
* Updated the scope format description and reference to the W3C DPV Purposes module in `CAMARA-Security-Interoperability.md` to use version 2.3.
* Updated the general reference to the W3C DPV in the References section of `CAMARA-Security-Interoperability.md` to version 2.3.

#### Which issue(s) this PR fixes:

Fixes #352

#### Special notes for reviewers:

TM Forum and/or GSMA should also update their references, but that is beyond the scope of this ICM issue.

#### Changelog input

```
 update dpv references to latest version
```

#### Additional documentation 

- https://w3c.github.io/dpv/2.3/dpv/
- ttps://w3c.github.io/dpv/2.3/dpv/modules/purposes 
